### PR TITLE
implemented recyclerview for assets and portfolio lists

### DIFF
--- a/app/src/main/java/lc/wise/finenancer/data/stub/StubData.kt
+++ b/app/src/main/java/lc/wise/finenancer/data/stub/StubData.kt
@@ -1,12 +1,13 @@
 package lc.wise.finenancer.data.stub
 
+import java.util.Date
 import lc.wise.finenancer.domain.entity.Asset
 import lc.wise.finenancer.domain.entity.Cash
 import lc.wise.finenancer.domain.entity.CashDetails
 import lc.wise.finenancer.domain.entity.Currency
+import lc.wise.finenancer.domain.entity.Portfolio
 import lc.wise.finenancer.domain.entity.Stock
 import lc.wise.finenancer.domain.entity.StockDetails
-import java.util.Date
 
 object StubData {
     val currencyList: List<Currency> = listOf(
@@ -38,4 +39,14 @@ object StubData {
     val StockDetailsList: List<StockDetails> = listOf(
         StockDetails(1, "GazProm", 23_673_512_900.0, 20_000.0, 2.0, 10_000.0, "RUB", Date())
     )
+
+    val portfolioList: List<Portfolio> = listOf(
+        Portfolio(1, "Portfolio 1", portfolioCashList, portfolioStockList),
+        Portfolio(2, "Portfolio 2", portfolioCashList, portfolioStockList),
+        Portfolio(3, "Portfolio 3", portfolioCashList, portfolioStockList),
+        Portfolio(4, "Portfolio 4", portfolioCashList, portfolioStockList),
+        Portfolio(5, "Portfolio 5", portfolioCashList, portfolioStockList),
+        Portfolio(6, "Portfolio 6", portfolioCashList, portfolioStockList)
+    )
+    // yes, just one portfolio planned, but...
 }

--- a/app/src/main/java/lc/wise/finenancer/data/stub/repository/StubPortfolioRepository.kt
+++ b/app/src/main/java/lc/wise/finenancer/data/stub/repository/StubPortfolioRepository.kt
@@ -1,0 +1,15 @@
+package lc.wise.finenancer.data.stub.repository
+
+import lc.wise.finenancer.data.stub.StubData
+import lc.wise.finenancer.domain.entity.Portfolio
+import lc.wise.finenancer.domain.repository.PortfolioRepository
+
+class StubPortfolioRepository : PortfolioRepository {
+    override fun createPortfolio() {}
+
+    override fun getPortfolioByID(portfolioID: Int): Portfolio? =
+        StubData.portfolioList.find { it.id == portfolioID }
+
+    override fun getAllPortfolios(): List<Portfolio> =
+        StubData.portfolioList
+}

--- a/app/src/main/java/lc/wise/finenancer/domain/entity/Portfolio.kt
+++ b/app/src/main/java/lc/wise/finenancer/domain/entity/Portfolio.kt
@@ -1,0 +1,15 @@
+package lc.wise.finenancer.domain.entity
+
+interface IPortfolio {
+    val id: Int
+    val name: String
+    val cashList: List<Cash>
+    val stockList: List<Stock>
+}
+
+data class Portfolio(
+    override val id: Int,
+    override val name: String,
+    override val cashList: List<Cash>,
+    override val stockList: List<Stock>
+) : IPortfolio

--- a/app/src/main/java/lc/wise/finenancer/domain/repository/PortfolioRepository.kt
+++ b/app/src/main/java/lc/wise/finenancer/domain/repository/PortfolioRepository.kt
@@ -1,0 +1,11 @@
+package lc.wise.finenancer.domain.repository
+
+import lc.wise.finenancer.domain.entity.Portfolio
+
+interface PortfolioRepository {
+    fun createPortfolio()
+    fun getPortfolioByID(portfolioID: Int): Portfolio?
+    fun getAllPortfolios(): List<Portfolio>
+//    fun updatePortfolio(portfolioID: Int): Portfolio?
+//    fun deletePortfolio(portfolioID: Int): Portfolio?
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/AssetsListFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/AssetsListFragment.kt
@@ -18,14 +18,21 @@ class AssetsListFragment : BaseFragment<FragmentAssetsListBinding>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setupAdapter()
+
+        setHasOptionsMenu(true)
+    }
+
+    private fun setupAdapter() {
         val adapter = AssetsListAdapter()
         binding.assetsList.adapter = adapter
 
-        // !! the following code is used to show that the recycler view works
+        // !! THE FOLLOWING CODE JUST SHOWS THAT THE RECYCLERVIEW WORKS
         // proper inflation with viewmodel + dependency injection + hilt
         // will be introduced in a separate PR
         val assetsList = StubData.assetList
-        adapter.submit(assetsList)
+        adapter.submitList(assetsList)
         adapter.onClick = {
             Toast.makeText(
                 requireActivity(),
@@ -33,8 +40,6 @@ class AssetsListFragment : BaseFragment<FragmentAssetsListBinding>() {
                 Toast.LENGTH_SHORT
             ).show()
         }
-
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -51,6 +56,7 @@ class AssetsListFragment : BaseFragment<FragmentAssetsListBinding>() {
                 ).show()
                 true
             }
+
             R.id.toolbar_options_edit -> {
                 Toast.makeText(
                     requireActivity(),
@@ -59,6 +65,7 @@ class AssetsListFragment : BaseFragment<FragmentAssetsListBinding>() {
                 ).show()
                 true
             }
+
             R.id.toolbar_options_delete -> {
                 Toast.makeText(
                     requireActivity(),
@@ -67,12 +74,14 @@ class AssetsListFragment : BaseFragment<FragmentAssetsListBinding>() {
                 ).show()
                 true
             }
+
             R.id.toolbar_options_settings -> {
                 findNavController().navigate(
                     AssetsListFragmentDirections.actionAssetsListFragmentToSettingsFragment()
                 )
                 true
             }
+
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/AssetsListFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/AssetsListFragment.kt
@@ -1,8 +1,79 @@
 package lc.wise.finenancer.presentation.assets.list
 
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.widget.Toast
+import androidx.navigation.fragment.findNavController
+import lc.wise.finenancer.R
+import lc.wise.finenancer.data.stub.StubData
 import lc.wise.finenancer.databinding.FragmentAssetsListBinding
-import lc.wise.finenancer.presentation.BaseFragment
+import lc.wise.finenancer.presentation.assets.list.rv.AssetsListAdapter
+import lc.wise.finenancer.presentation.utils.BaseFragment
 
 class AssetsListFragment : BaseFragment<FragmentAssetsListBinding>() {
     override fun inflateBinding() = FragmentAssetsListBinding.inflate(layoutInflater)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val adapter = AssetsListAdapter()
+        binding.assetsList.adapter = adapter
+
+        // !! the following code is used to show that the recycler view works
+        // proper inflation with viewmodel + dependency injection + hilt
+        // will be introduced in a separate PR
+        val assetsList = StubData.assetList
+        adapter.submit(assetsList)
+        adapter.onClick = {
+            Toast.makeText(
+                requireActivity(),
+                "Asset Info - Work In Progress",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.toolbar_options, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.toolbar_options_create -> {
+                Toast.makeText(
+                    requireActivity(),
+                    "Create Asset - Work In Progress",
+                    Toast.LENGTH_SHORT
+                ).show()
+                true
+            }
+            R.id.toolbar_options_edit -> {
+                Toast.makeText(
+                    requireActivity(),
+                    "Edit Asset - Work In Progress",
+                    Toast.LENGTH_SHORT
+                ).show()
+                true
+            }
+            R.id.toolbar_options_delete -> {
+                Toast.makeText(
+                    requireActivity(),
+                    "Delete Asset - Work In Progress",
+                    Toast.LENGTH_SHORT
+                ).show()
+                true
+            }
+            R.id.toolbar_options_settings -> {
+                findNavController().navigate(
+                    AssetsListFragmentDirections.actionAssetsListFragmentToSettingsFragment()
+                )
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListAdapter.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListAdapter.kt
@@ -1,0 +1,32 @@
+package lc.wise.finenancer.presentation.assets.list.rv
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView.Adapter
+import lc.wise.finenancer.databinding.ItemAssetBinding
+import lc.wise.finenancer.domain.entity.Asset
+
+class AssetsListAdapter : Adapter<AssetsListViewHolder>() {
+
+    var onClick: (Asset) -> Unit = {}
+    private var assetList = emptyList<Asset>()
+    override fun getItemCount() = assetList.size
+
+    fun submit(newAssetList: List<Asset>) {
+        val diffCallback = AssetsListDiffUtil(assetList, newAssetList)
+        val diffAssets = DiffUtil.calculateDiff(diffCallback)
+        assetList = newAssetList
+        diffAssets.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AssetsListViewHolder {
+        return AssetsListViewHolder(
+            ItemAssetBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    override fun onBindViewHolder(holder: AssetsListViewHolder, position: Int) {
+        holder.bind(assetList[position], onClick)
+    }
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListAdapter.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListAdapter.kt
@@ -2,23 +2,13 @@ package lc.wise.finenancer.presentation.assets.list.rv
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView.Adapter
+import androidx.recyclerview.widget.ListAdapter
 import lc.wise.finenancer.databinding.ItemAssetBinding
 import lc.wise.finenancer.domain.entity.Asset
 
-class AssetsListAdapter : Adapter<AssetsListViewHolder>() {
+class AssetsListAdapter : ListAdapter<Asset, AssetsListViewHolder>(AssetsListDiffUtil()) {
 
     var onClick: (Asset) -> Unit = {}
-    private var assetList = emptyList<Asset>()
-    override fun getItemCount() = assetList.size
-
-    fun submit(newAssetList: List<Asset>) {
-        val diffCallback = AssetsListDiffUtil(assetList, newAssetList)
-        val diffAssets = DiffUtil.calculateDiff(diffCallback)
-        assetList = newAssetList
-        diffAssets.dispatchUpdatesTo(this)
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AssetsListViewHolder {
         return AssetsListViewHolder(
@@ -27,6 +17,6 @@ class AssetsListAdapter : Adapter<AssetsListViewHolder>() {
     }
 
     override fun onBindViewHolder(holder: AssetsListViewHolder, position: Int) {
-        holder.bind(assetList[position], onClick)
+        holder.bind(getItem(position), onClick)
     }
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListDiffUtil.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListDiffUtil.kt
@@ -3,22 +3,10 @@ package lc.wise.finenancer.presentation.assets.list.rv
 import androidx.recyclerview.widget.DiffUtil
 import lc.wise.finenancer.domain.entity.Asset
 
-class AssetsListDiffUtil(
-    private val oldAssetList: List<Asset>,
-    private val newAssetList: List<Asset>
-) : DiffUtil.Callback() {
-    override fun getOldListSize() = oldAssetList.size
-    override fun getNewListSize() = newAssetList.size
+class AssetsListDiffUtil : DiffUtil.ItemCallback<Asset>() {
+    override fun areItemsTheSame(oldItem: Asset, newItem: Asset): Boolean =
+        oldItem == newItem
 
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldAsset = oldAssetList[oldItemPosition]
-        val newAsset = newAssetList[newItemPosition]
-        return oldAsset.id == newAsset.id
-    }
-
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldAsset = oldAssetList[oldItemPosition]
-        val newAsset = newAssetList[newItemPosition]
-        return oldAsset == newAsset
-    }
+    override fun areContentsTheSame(oldItem: Asset, newItem: Asset): Boolean =
+        oldItem == newItem
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListDiffUtil.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListDiffUtil.kt
@@ -1,0 +1,24 @@
+package lc.wise.finenancer.presentation.assets.list.rv
+
+import androidx.recyclerview.widget.DiffUtil
+import lc.wise.finenancer.domain.entity.Asset
+
+class AssetsListDiffUtil(
+    private val oldAssetList: List<Asset>,
+    private val newAssetList: List<Asset>
+) : DiffUtil.Callback() {
+    override fun getOldListSize() = oldAssetList.size
+    override fun getNewListSize() = newAssetList.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldAsset = oldAssetList[oldItemPosition]
+        val newAsset = newAssetList[newItemPosition]
+        return oldAsset.id == newAsset.id
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldAsset = oldAssetList[oldItemPosition]
+        val newAsset = newAssetList[newItemPosition]
+        return oldAsset == newAsset
+    }
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListViewHolder.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/assets/list/rv/AssetsListViewHolder.kt
@@ -1,0 +1,20 @@
+package lc.wise.finenancer.presentation.assets.list.rv
+
+import androidx.recyclerview.widget.RecyclerView
+import lc.wise.finenancer.R
+import lc.wise.finenancer.databinding.ItemAssetBinding
+import lc.wise.finenancer.domain.entity.Asset
+
+class AssetsListViewHolder(
+    private val binding: ItemAssetBinding // there are also currencies, what do we do for them?
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(asset: Asset, onClick: (Asset) -> Unit) {
+        with(binding) {
+            assetIcon.setImageResource(R.drawable.ic_launcher_foreground)
+            assetName.text = asset.name
+            root.setOnClickListener {
+                onClick(asset)
+            }
+        }
+    }
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/home/HomeFragment.kt
@@ -1,10 +1,14 @@
 package lc.wise.finenancer.presentation.home
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.navigation.fragment.findNavController
+import lc.wise.finenancer.R
 import lc.wise.finenancer.databinding.FragmentHomeBinding
-import lc.wise.finenancer.presentation.BaseFragment
+import lc.wise.finenancer.presentation.utils.BaseFragment
 
 class HomeFragment : BaseFragment<FragmentHomeBinding>() {
     override fun inflateBinding() = FragmentHomeBinding.inflate(layoutInflater)
@@ -12,21 +16,36 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>() {
         super.onViewCreated(view, savedInstanceState)
 
         with(binding) {
-            assetsList.setOnClickListener {
+            buttonAssetsList.setOnClickListener {
                 findNavController().navigate(
                     HomeFragmentDirections.actionHomeFragmentToAssetsListFragment()
                 )
             }
-            portfolioList.setOnClickListener {
+            buttonPortfolioList.setOnClickListener {
                 findNavController().navigate(
                     HomeFragmentDirections.actionHomeFragmentToPortfolioListFragment()
                 )
             }
-            settings.setOnClickListener {
+        }
+
+        // this also should be moved to home fragment viewmodel
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.home_fragment_settings, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.home_toolbar_settings -> {
                 findNavController().navigate(
                     HomeFragmentDirections.actionHomeFragmentToSettingsFragment()
                 )
-            } // we're doing it as a button on home screen for now but it being always
-        } // available in the toolbar with back button and fragment name is cooler
+                true
+            }
+
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/PortfolioListFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/PortfolioListFragment.kt
@@ -18,6 +18,13 @@ class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        setupAdapter()
+
+        setHasOptionsMenu(true)
+    }
+
+    private fun setupAdapter() {
         val adapter = PortfolioListAdapter()
         binding.portfolioList.adapter = adapter
 
@@ -25,7 +32,7 @@ class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
         // proper inflation with viewmodel + dependency injection + hilt
         // will be introduced in a separate PR
         val portfolioList = StubData.portfolioList
-        adapter.submit(portfolioList)
+        adapter.submitList(portfolioList)
         adapter.onClick = {
             Toast.makeText(
                 requireActivity(),
@@ -33,8 +40,6 @@ class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
                 Toast.LENGTH_SHORT
             ).show()
         }
-
-        setHasOptionsMenu(true)
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -51,6 +56,7 @@ class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
                 ).show()
                 true
             }
+
             R.id.toolbar_options_edit -> {
                 Toast.makeText(
                     requireActivity(),
@@ -59,6 +65,7 @@ class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
                 ).show()
                 true
             }
+
             R.id.toolbar_options_delete -> {
                 Toast.makeText(
                     requireActivity(),
@@ -67,12 +74,14 @@ class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
                 ).show()
                 true
             }
+
             R.id.toolbar_options_settings -> {
                 findNavController().navigate(
                     PortfolioListFragmentDirections.actionPortfolioListFragmentToSettingsFragment()
                 )
                 true
             }
+
             else -> super.onOptionsItemSelected(item)
         }
     }

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/PortfolioListFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/PortfolioListFragment.kt
@@ -1,8 +1,79 @@
 package lc.wise.finenancer.presentation.portfolio.list
 
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.widget.Toast
+import androidx.navigation.fragment.findNavController
+import lc.wise.finenancer.R
+import lc.wise.finenancer.data.stub.StubData
 import lc.wise.finenancer.databinding.FragmentPortfolioListBinding
-import lc.wise.finenancer.presentation.BaseFragment
+import lc.wise.finenancer.presentation.portfolio.list.rv.PortfolioListAdapter
+import lc.wise.finenancer.presentation.utils.BaseFragment
 
 class PortfolioListFragment : BaseFragment<FragmentPortfolioListBinding>() {
     override fun inflateBinding() = FragmentPortfolioListBinding.inflate(layoutInflater)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val adapter = PortfolioListAdapter()
+        binding.portfolioList.adapter = adapter
+
+        // !! THE FOLLOWING CODE JUST SHOWS THAT THE RECYCLERVIEW WORKS
+        // proper inflation with viewmodel + dependency injection + hilt
+        // will be introduced in a separate PR
+        val portfolioList = StubData.portfolioList
+        adapter.submit(portfolioList)
+        adapter.onClick = {
+            Toast.makeText(
+                requireActivity(),
+                "Portfolio Info - Work In Progress",
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+
+        setHasOptionsMenu(true)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        inflater.inflate(R.menu.toolbar_options, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.toolbar_options_create -> {
+                Toast.makeText(
+                    requireActivity(),
+                    "Create Portfolio - Work In Progress",
+                    Toast.LENGTH_SHORT
+                ).show()
+                true
+            }
+            R.id.toolbar_options_edit -> {
+                Toast.makeText(
+                    requireActivity(),
+                    "Edit Portfolio - Work In Progress",
+                    Toast.LENGTH_SHORT
+                ).show()
+                true
+            }
+            R.id.toolbar_options_delete -> {
+                Toast.makeText(
+                    requireActivity(),
+                    "Delete Portfolio - Work In Progress",
+                    Toast.LENGTH_SHORT
+                ).show()
+                true
+            }
+            R.id.toolbar_options_settings -> {
+                findNavController().navigate(
+                    PortfolioListFragmentDirections.actionPortfolioListFragmentToSettingsFragment()
+                )
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListAdapter.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListAdapter.kt
@@ -2,23 +2,14 @@ package lc.wise.finenancer.presentation.portfolio.list.rv
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.ListAdapter
 import lc.wise.finenancer.databinding.ItemPortfolioBinding
 import lc.wise.finenancer.domain.entity.Portfolio
 
-class PortfolioListAdapter : RecyclerView.Adapter<PortfolioListViewHolder>() {
+class PortfolioListAdapter :
+    ListAdapter<Portfolio, PortfolioListViewHolder>(PortfolioListDiffUtil()) {
 
     var onClick: (Portfolio) -> Unit = {}
-    private var portfolioList = emptyList<Portfolio>()
-    override fun getItemCount() = portfolioList.size
-
-    fun submit(newPortfolioList: List<Portfolio>) {
-        val diffCallback = PortfolioListDiffUtil(portfolioList, newPortfolioList)
-        val diffAssets = DiffUtil.calculateDiff(diffCallback)
-        portfolioList = newPortfolioList
-        diffAssets.dispatchUpdatesTo(this)
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PortfolioListViewHolder {
         return PortfolioListViewHolder(
@@ -27,6 +18,6 @@ class PortfolioListAdapter : RecyclerView.Adapter<PortfolioListViewHolder>() {
     }
 
     override fun onBindViewHolder(holder: PortfolioListViewHolder, position: Int) {
-        holder.bind(portfolioList[position], onClick)
+        holder.bind(getItem(position), onClick)
     }
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListAdapter.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListAdapter.kt
@@ -1,0 +1,32 @@
+package lc.wise.finenancer.presentation.portfolio.list.rv
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import lc.wise.finenancer.databinding.ItemPortfolioBinding
+import lc.wise.finenancer.domain.entity.Portfolio
+
+class PortfolioListAdapter : RecyclerView.Adapter<PortfolioListViewHolder>() {
+
+    var onClick: (Portfolio) -> Unit = {}
+    private var portfolioList = emptyList<Portfolio>()
+    override fun getItemCount() = portfolioList.size
+
+    fun submit(newPortfolioList: List<Portfolio>) {
+        val diffCallback = PortfolioListDiffUtil(portfolioList, newPortfolioList)
+        val diffAssets = DiffUtil.calculateDiff(diffCallback)
+        portfolioList = newPortfolioList
+        diffAssets.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PortfolioListViewHolder {
+        return PortfolioListViewHolder(
+            ItemPortfolioBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        )
+    }
+
+    override fun onBindViewHolder(holder: PortfolioListViewHolder, position: Int) {
+        holder.bind(portfolioList[position], onClick)
+    }
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListDiffUtil.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListDiffUtil.kt
@@ -3,22 +3,10 @@ package lc.wise.finenancer.presentation.portfolio.list.rv
 import androidx.recyclerview.widget.DiffUtil
 import lc.wise.finenancer.domain.entity.Portfolio
 
-class PortfolioListDiffUtil(
-    private val oldPortfolioList: List<Portfolio>,
-    private val newPortfolioList: List<Portfolio>
-) : DiffUtil.Callback() {
-    override fun getOldListSize() = oldPortfolioList.size
-    override fun getNewListSize() = newPortfolioList.size
+class PortfolioListDiffUtil : DiffUtil.ItemCallback<Portfolio>() {
+    override fun areItemsTheSame(oldItem: Portfolio, newItem: Portfolio): Boolean =
+        oldItem == newItem
 
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldPortfolio = oldPortfolioList[oldItemPosition]
-        val newPortfolio = newPortfolioList[newItemPosition]
-        return oldPortfolio.id == newPortfolio.id
-    }
-
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        val oldPortfolio = oldPortfolioList[oldItemPosition]
-        val newPortfolio = newPortfolioList[newItemPosition]
-        return oldPortfolio == newPortfolio
-    }
+    override fun areContentsTheSame(oldItem: Portfolio, newItem: Portfolio): Boolean =
+        oldItem == newItem
 }

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListDiffUtil.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListDiffUtil.kt
@@ -1,0 +1,24 @@
+package lc.wise.finenancer.presentation.portfolio.list.rv
+
+import androidx.recyclerview.widget.DiffUtil
+import lc.wise.finenancer.domain.entity.Portfolio
+
+class PortfolioListDiffUtil(
+    private val oldPortfolioList: List<Portfolio>,
+    private val newPortfolioList: List<Portfolio>
+) : DiffUtil.Callback() {
+    override fun getOldListSize() = oldPortfolioList.size
+    override fun getNewListSize() = newPortfolioList.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldPortfolio = oldPortfolioList[oldItemPosition]
+        val newPortfolio = newPortfolioList[newItemPosition]
+        return oldPortfolio.id == newPortfolio.id
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldPortfolio = oldPortfolioList[oldItemPosition]
+        val newPortfolio = newPortfolioList[newItemPosition]
+        return oldPortfolio == newPortfolio
+    }
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListViewHolder.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/portfolio/list/rv/PortfolioListViewHolder.kt
@@ -1,0 +1,20 @@
+package lc.wise.finenancer.presentation.portfolio.list.rv
+
+import androidx.recyclerview.widget.RecyclerView
+import lc.wise.finenancer.R
+import lc.wise.finenancer.databinding.ItemPortfolioBinding
+import lc.wise.finenancer.domain.entity.Portfolio
+
+class PortfolioListViewHolder(
+    private val binding: ItemPortfolioBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(portfolio: Portfolio, onClick: (Portfolio) -> Unit) {
+        with(binding) {
+            portfolioIcon.setImageResource(R.drawable.ic_launcher_foreground)
+            portfolioName.text = portfolio.name
+            root.setOnClickListener {
+                onClick(portfolio)
+            }
+        }
+    }
+}

--- a/app/src/main/java/lc/wise/finenancer/presentation/settings/SettingsFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/settings/SettingsFragment.kt
@@ -1,7 +1,7 @@
 package lc.wise.finenancer.presentation.settings
 
 import lc.wise.finenancer.databinding.FragmentSettingsBinding
-import lc.wise.finenancer.presentation.BaseFragment
+import lc.wise.finenancer.presentation.utils.BaseFragment
 
 class SettingsFragment : BaseFragment<FragmentSettingsBinding>() {
     override fun inflateBinding() = FragmentSettingsBinding.inflate(layoutInflater)

--- a/app/src/main/java/lc/wise/finenancer/presentation/utils/BaseFragment.kt
+++ b/app/src/main/java/lc/wise/finenancer/presentation/utils/BaseFragment.kt
@@ -1,4 +1,4 @@
-package lc.wise.finenancer.presentation
+package lc.wise.finenancer.presentation.utils
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -18,7 +18,7 @@
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingTop="?attr/actionBarSize"
+        android:layout_marginTop="?attr/actionBarSize"
         app:navGraph="@navigation/navigation" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_assets_list.xml
+++ b/app/src/main/res/layout/fragment_assets_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -8,15 +8,12 @@
     android:padding="16dp"
     tools:context=".presentation.assets.list.AssetsListFragment">
 
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:textSize="64sp"
-        android:gravity="center"
-        android:text="Assets List Fragment\nWIP"/>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/assets_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,54 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
+    android:orientation="vertical"
+    android:weightSum="1"
     tools:context=".presentation.home.HomeFragment">
 
     <Button
-        android:id="@+id/assets_list"
-        android:layout_width="0dp"
+        android:id="@+id/button_assets_list"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_weight="0.33"
         android:layout_marginBottom="8dp"
-        app:layout_constraintBottom_toTopOf="@id/portfolio_list"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
         android:text="Assets List"
         android:textSize="64sp"
         android:gravity="center"
         app:cornerRadius="24dp" />
 
     <Button
-        android:id="@+id/portfolio_list"
-        android:layout_width="0dp"
+        android:id="@+id/button_portfolio_list"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_weight="0.33"
         android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        app:layout_constraintBottom_toTopOf="@id/settings"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/assets_list"
         android:text="Portfolio List"
         android:textSize="64sp"
         android:gravity="center"
         app:cornerRadius="24dp" />
 
-    <Button
-        android:id="@+id/settings"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/portfolio_list"
-        android:text="Settings"
-        android:textSize="64sp"
-        android:gravity="center"
-        app:cornerRadius="24dp" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -16,7 +16,7 @@
         android:layout_height="0dp"
         android:layout_weight="0.33"
         android:layout_marginBottom="8dp"
-        android:text="Assets List"
+        android:text="@string/assets_list"
         android:textSize="64sp"
         android:gravity="center"
         app:cornerRadius="24dp" />
@@ -27,7 +27,7 @@
         android:layout_height="0dp"
         android:layout_weight="0.33"
         android:layout_marginTop="8dp"
-        android:text="Portfolio List"
+        android:text="@string/portfolio_list"
         android:textSize="64sp"
         android:gravity="center"
         app:cornerRadius="24dp" />

--- a/app/src/main/res/layout/fragment_portfolio_list.xml
+++ b/app/src/main/res/layout/fragment_portfolio_list.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -8,15 +8,12 @@
     android:padding="16dp"
     tools:context=".presentation.portfolio.list.PortfolioListFragment">
 
-    <TextView
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:textSize="64sp"
-        android:gravity="center"
-        android:text="Portfolio List Fragment\nWIP"/>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/portfolio_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/item_asset.xml
+++ b/app/src/main/res/layout/item_asset.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/asset_icon"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="0.3"
+        tools:src="@drawable/ic_launcher_foreground" />
+
+    <TextView
+        android:id="@+id/asset_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.7"
+        android:textAlignment="viewStart"
+        android:textSize="48sp"
+        tools:text="Asset" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_portfolio.xml
+++ b/app/src/main/res/layout/item_portfolio.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/portfolio_icon"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="0.3"
+        tools:src="@drawable/ic_launcher_foreground" />
+
+    <TextView
+        android:id="@+id/portfolio_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="0.7"
+        android:textAlignment="viewStart"
+        android:textSize="48sp"
+        tools:text="Portfolio" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/home_fragment_settings.xml
+++ b/app/src/main/res/menu/home_fragment_settings.xml
@@ -5,7 +5,7 @@
     <item
         android:id="@+id/home_toolbar_settings"
         android:icon="@drawable/ic_launcher_foreground"
-        android:title="App Settings"
+        android:title="@string/settings"
         app:showAsAction="always" />
 
 </menu>

--- a/app/src/main/res/menu/home_fragment_settings.xml
+++ b/app/src/main/res/menu/home_fragment_settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/home_toolbar_settings"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="App Settings"
+        app:showAsAction="always" />
+
+</menu>

--- a/app/src/main/res/menu/toolbar_options.xml
+++ b/app/src/main/res/menu/toolbar_options.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/toolbar_options_create"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="Create New"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/toolbar_options_edit"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="Edit Existing"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/toolbar_options_delete"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="Delete Existing"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/toolbar_options_settings"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:title="App Settings"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/menu/toolbar_options.xml
+++ b/app/src/main/res/menu/toolbar_options.xml
@@ -5,25 +5,25 @@
     <item
         android:id="@+id/toolbar_options_create"
         android:icon="@drawable/ic_launcher_foreground"
-        android:title="Create New"
+        android:title="@string/create"
         app:showAsAction="never" />
 
     <item
         android:id="@+id/toolbar_options_edit"
         android:icon="@drawable/ic_launcher_foreground"
-        android:title="Edit Existing"
+        android:title="@string/edit"
         app:showAsAction="never" />
 
     <item
         android:id="@+id/toolbar_options_delete"
         android:icon="@drawable/ic_launcher_foreground"
-        android:title="Delete Existing"
+        android:title="@string/delete"
         app:showAsAction="never" />
 
     <item
         android:id="@+id/toolbar_options_settings"
         android:icon="@drawable/ic_launcher_foreground"
-        android:title="App Settings"
+        android:title="@string/settings"
         app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/navigation/navigation.xml
+++ b/app/src/main/res/navigation/navigation.xml
@@ -36,12 +36,28 @@
         android:id="@+id/assetsListFragment"
         android:name="lc.wise.finenancer.presentation.assets.list.AssetsListFragment"
         android:label="Assets List"
-        tools:layout="@layout/fragment_assets_list" />
+        tools:layout="@layout/fragment_assets_list" >
+        <action
+            android:id="@+id/action_assetsListFragment_to_settingsFragment"
+            app:destination="@id/settingsFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+    </fragment>
     <fragment
         android:id="@+id/portfolioListFragment"
         android:name="lc.wise.finenancer.presentation.portfolio.list.PortfolioListFragment"
         android:label="Portfolio List"
-        tools:layout="@layout/fragment_portfolio_list" />
+        tools:layout="@layout/fragment_portfolio_list" >
+        <action
+            android:id="@+id/action_portfolioListFragment_to_settingsFragment"
+            app:destination="@id/settingsFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+    </fragment>
     <fragment
         android:id="@+id/settingsFragment"
         android:name="lc.wise.finenancer.presentation.settings.SettingsFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
 <resources>
     <string name="app_name">Finenancer</string>
+    <string name="assets_list">Assets List</string>
+    <string name="portfolio_list">Portfolio List</string>
+    <string name="create">Create New</string>
+    <string name="edit">Edit Existing</string>
+    <string name="delete">Delete Existing</string>
+    <string name="settings">App Settings</string>
 </resources>


### PR DESCRIPTION
IMPORTANT: VIEW MODELS NOT IMPLEMENTED YET, THEY WILL BE INTRODUCED IN SEPARATE PR

- added recycler view implementation to assets list and portfolio list screens
- added toolbar options for assets list and portfolio list screens, not yet implemented
- moved settings button on home screen to a toolbar
- now settings fragment is accessed from a separate button on a toolbar (home fragment)
   or the options menu on a toolbar (assets list and portfolio list screens)
